### PR TITLE
fix: restore Redis service configuration in CI workflow and update environment variable for Redis URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,11 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Install packages
@@ -73,5 +73,5 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
+          REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test


### PR DESCRIPTION
This pull request updates the continuous integration workflow to enable and configure Redis for testing. The most important changes are:

**CI Infrastructure Updates:**

* Uncomments and enables the `redis` service in the `jobs.services` section of `.github/workflows/ci.yml`, ensuring Redis is available during CI runs.
* Sets the `REDIS_URL` environment variable to `redis://localhost:6379/0` for test jobs, allowing the application to connect to the Redis instance during tests.